### PR TITLE
fix  perl regex to extract the audit stats

### DIFF
--- a/updater/scripts/git-download.sh
+++ b/updater/scripts/git-download.sh
@@ -20,15 +20,20 @@ if ghe_greater_equal "2.11.0" ; then
     # most recent log files (because the information from yesterday may or not
     # be rotated already).
     CAT_LOG_FILE="zcat -f /var/log/github-audit.{log.1*,log} | grep -F '$(date --date='yesterday' +'%b %_d')'"
+
+    # The order in github-audit.log in GHE 2.12.x has been changed, to pick the right order PERL_REGEX is created.
+    PERL_REGEX='print if s/.*"cloning":([^,]+).*"program":"upload-pack".*"repo_name":"([^"]+).*"uploaded_bytes":([^,]+).*"user_login":"([^"]+).*/\2\t\4\t\1\t\3/'
+
 else
     # check yesterday's log file
     CAT_LOG_FILE="zcat -f /var/log/github/audit.log.1*"
+    PERL_REGEX='print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/'
 fi
 
 echo -e "repository\tuser\tcloning?\trequests/day\tdownload/day [B]"
 
 eval "$CAT_LOG_FILE" |
-    perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
+    perl -ne "$PERL_REGEX" |
     sort |
     perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |
     sort -rn -k5,5


### PR DESCRIPTION
Due to a log format (order) change on github-audit.log.* on GHE 2.12.x (we tested that on GHE 2.12.3), git-download.sh is broken.

Here is a proposal to fix it using awk:

Current one which works on =<2.11.x
```
eval "$CAT_LOG_FILE" |
    perl -ne 'print if s/.*"program":"upload-pack".*"repo_name":"([^"]+).*"user_login":"([^"]+).*"cloning":([^,]+).*"uploaded_bytes":([^ ]+).*/\1\t\2\t\3\t\4/' |
    sort |
    perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}' |
    sort -rn -k5,5
```

For GHE >=2.12
```
eval "$CAT_LOG_FILE" |
	perl -ne 'print if s/.*"cloning":([^,]+).*"program":"upload-pack".*"repo_name":"([^"]+).*"uploaded_bytes":([^,]+).*"user_login":"([^"]+).*/\2\t\4\t\1\t\3/'
	| sort
	| perl -ne '$S{$1} += $2 and $C{$1} += 1 if (/^(.+)\t(\d+)$/);END{printf("%s\t%i\t%i\n",$_,$C{$_},$S{$_}) for ( keys %S );}'
	| sort -rn -k5,5
```